### PR TITLE
switch to streamable github mcp server served by Github and add a exa…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+OPENAI_API_KEY = "your openai api key"
+GITHUB_MCP_URL = "https://api.githubcopilot.com/mcp/"
+TAVILY_API_KEY = "your tavily api key"
+GITHUB_PAT="your gitub personal token"


### PR DESCRIPTION
Key changes:

1. Switched to the streamable GitHub MCP server hosted by GitHub. This streamlines our efforts and removes the need to deploy the GitHub MCP server ourselves.
3. Added a `.env.example` file under the `/backend` folder.